### PR TITLE
Add Missing Text-Domain

### DIFF
--- a/build/inc/FLoC/Component.php
+++ b/build/inc/FLoC/Component.php
@@ -59,18 +59,18 @@ class Component implements Component_Interface {
 	public function blocking_methods( $methods = array() ) {
 
 		$methods['none'] = array(
-			'title'       => __( 'None / Allow FLoC' ),
+			'title'       => __( 'None / Allow FLoC', 'wpm-floc' ),
 			'description' => __( 'This method does not provide an opt-out from FLoC.', 'wpm-floc' ),
 		);
 
 		$methods['simple'] = array(
 			'title'       => __( 'Simple / PHP' ),
-			'callback'    => array( $this, 'initialize_simple' ),
+			'callback'    => array( $this, 'initialize_simple', 'wpm-floc' ),
 			'description' => __( 'Works for most WordPress setups. Uses the "wp_headers" filter to provide the HTTP header.', 'wpm-floc' ),
 		);
 
 		$methods['apache'] = array(
-			'title'       => __( 'Apache / .htaccess' ),
+			'title'       => __( 'Apache / .htaccess', 'wpm-floc' ),
 			'callback'    => array( $this, 'initialize_apache' ),
 			'description' => __( 'When you have to circumvent your cache. Works on apache servers with the "mod_headers" module installed. Writes the header into the .htaccess file.', 'wpm-floc' ),
 		);

--- a/build/inc/Settings/Component.php
+++ b/build/inc/Settings/Component.php
@@ -138,7 +138,7 @@ class Component implements Component_Interface {
 
 		echo $select;
 
-		$description = '<p class="description">' . __( 'Select a FLoC blocking method suitable for your system. <br />You can learn more about the blocking methods in the help section of this page.' ) . '</p>';
+		$description = '<p class="description">' . __( 'Select a FLoC blocking method suitable for your system. <br />You can learn more about the blocking methods in the help section of this page.', 'wpm-floc' ) . '</p>';
 
 		echo $description;
 	}
@@ -162,7 +162,7 @@ class Component implements Component_Interface {
 
 		echo $button;
 
-		$description = '<p class="description">' . __( 'Click this button to check if the FLoC header is present in the frontend.' ) . '</p>';
+		$description = '<p class="description">' . __( 'Click this button to check if the FLoC header is present in the frontend.', 'wpm-floc' ) . '</p>';
 
 		echo $description;
 	}


### PR DESCRIPTION
Just add missing text-domain for localization.
UI strings with missing text-domain can't display their own translations correctly.